### PR TITLE
Code-Checker: nette.min.php path fix

### DIFF
--- a/Code-Checker/code-checker.phpc
+++ b/Code-Checker/code-checker.phpc
@@ -9,7 +9,7 @@
  * the file license.txt that was distributed with this source code.
  */
 
-require __DIR__ . '/../nette.min.php';
+require __DIR__ . '/../../Nette-minified/nette.min.php';
 
 use Nette\Utils\Strings;
 


### PR DESCRIPTION
Ve dnešním dev buildu jsem našel špatnou cestu. Code-Checker nenajde nette.min.php. Takže tady je oprava.
