### PR TITLE
Define __DIR__ for older PHP versions than 5.3

### DIFF
--- a/Requirements-Checker/checker.php
+++ b/Requirements-Checker/checker.php
@@ -24,6 +24,15 @@ foreach (array('function_exists', 'version_compare', 'extension_loaded', 'ini_ge
 
 
 /**
+ * Declare __DIR__ constant for PHP older than 5.3.0 so the script will run on older servers.
+ */
+if (version_compare(PHP_VERSION, '5.3.0', '<')) {
+	define('__DIR__', dirname(__FILE__));
+}
+
+
+
+/**
  * Check assets folder, template file must be readable
  */
 define('TEMPLATE_FILE', __DIR__ . '/assets/checker.phtml');


### PR DESCRIPTION
Fixes problem when checker displays error "Error: template file is not readable. Check assets folder (part of distribution), it should be present, readable and contain readable template file." on systems without PHP 5.3.0 enabled.
