### PR TITLE
bugfix/problem with path to autoload.php

### DIFF
--- a/code-checker
+++ b/code-checker
@@ -1,4 +1,11 @@
 #!/usr/bin/env php
 <?php
 
+$autoloaderInWorkingDirectory = getcwd() . '/vendor/autoload.php';
+
+if (@!include $autoloaderInWorkingDirectory) {
+    echo 'Install packages using `composer update` - cannot find autoload.php'  ;
+    exit(1);
+}
+
 require __DIR__ . '/src/bootstrap.php';

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -10,11 +10,6 @@ namespace Nette\CodeChecker;
 
 use Nette\CommandLine\Parser;
 
-if (@!include __DIR__ . '/../vendor/autoload.php') {
-	echo 'Install packages using `composer update`';
-	exit(1);
-}
-
 set_exception_handler(function ($e) {
 	echo "Error: {$e->getMessage()}\n";
 	die(2);


### PR DESCRIPTION
- bug fix? yes 
- new feature? no
- BC break? no

Code-checker cannot find autload.php If it was run from ./vendor/bin/code-checker